### PR TITLE
tool: cleaner println built-in

### DIFF
--- a/tool/src/main/kotlin/gay/pizza/pork/tool/RunCommand.kt
+++ b/tool/src/main/kotlin/gay/pizza/pork/tool/RunCommand.kt
@@ -23,8 +23,10 @@ class RunCommand : CliktCommand(help = "Run Program", name = "run") {
       if (quiet) {
         return@CallableFunction None
       }
-      for (argument in arguments.values) {
-        println(argument)
+      when (arguments.values.count()) {
+        0 -> println()
+        1 -> println(arguments.values[0])
+        else -> println(arguments.values.joinToString(" "))
       }
       None
     })


### PR DESCRIPTION
No arguments now prints a newline
Multiple arguments are now separated by a space 